### PR TITLE
feat: Add Google Calendar integration for email drafting context

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,3 +44,10 @@ var GEMINI_API_KEY = "INSERT_GEMINI_API_KEY_HERE";
     *   **Permissions**: Using this feature requires granting the script permission to access your Google Docs.
 
 Enjoy! Feedback is welcome. Contact the repository owner via email.
+
+## Google Calendar Integration
+This script can integrate with your Google Calendar to provide context for email drafting.
+- When enabled, it fetches events from your default calendar for the next 30 days.
+- This calendar information is then formatted as CSV and included in the prompt sent to the AI.
+- The CSV format is: `Date,Start Time,End Time,Name,Description,Participants,Location`.
+- You can disable this feature by setting the `enableCalendarIntegration` variable in `autodraft.js` to `false`. By default, it is `true`.


### PR DESCRIPTION
This feature adds the capability to fetch events from your Google Calendar and incorporate them into the context provided to the Gemini API for drafting emails.

Key changes:
- Added an `enableCalendarIntegration` flag in `autodraft.js` (default: true) to control this feature.
- Implemented `getCalendarEvents()` function to fetch the next 30 days of calendar events.
- Events are formatted into a CSV string with fields: Date, Start Time, End Time, Name, Description, Participants, Location. Long strings are clipped.
- The calendar CSV data is prepended to the prompt sent to the Gemini API if the feature is enabled and events are found.
- Updated README.md to document the new feature, its configuration, and the CSV format.

Output: